### PR TITLE
Add Ellsworth.ai — Creator role and link block

### DIFF
--- a/index.html
+++ b/index.html
@@ -407,8 +407,12 @@
       <div class="section-accent"></div>
       <h2 class="section-title">Where I&rsquo;ve Worked</h2>
     </div>
-    <p class="section-intro">Roles across AI, SaaS, healthcare, and enterprise product design.</p>
+    <p class="section-intro">Creator, founder, and designer &mdash; spanning AI, SaaS, healthcare, and enterprise product design.</p>
     <div class="exp-list">
+      <div class="exp-item">
+        <div><span class="exp-company">Ellsworth.ai</span><span class="exp-role">Creator</span></div>
+        <span class="exp-period">2026</span>
+      </div>
       <div class="exp-item">
         <div><span class="exp-company">CoPlane</span><span class="exp-role">Product Design Engineer (Contract)</span></div>
         <span class="exp-period">2025</span>

--- a/index.html
+++ b/index.html
@@ -296,6 +296,7 @@
     <a href="https://linkedin.com/in/hamiltonstudio" target="_blank" class="btn btn-ghost">LinkedIn</a>
     <a href="https://github.com/danielhamilton" target="_blank" class="btn btn-ghost">GitHub</a>
     <a href="https://hamilton.studio" target="_blank" class="btn btn-ghost">hamilton.studio</a>
+    <a href="https://ellsworth.ai" target="_blank" class="btn btn-ghost">Ellsworth.ai</a>
   </div>
 </header>
 
@@ -529,6 +530,7 @@
       <a href="https://linkedin.com/in/hamiltonstudio" target="_blank" class="footer-link">LinkedIn</a>
       <a href="https://github.com/danielhamilton" target="_blank" class="footer-link">GitHub</a>
       <a href="https://hamilton.studio" target="_blank" class="footer-link">Hamilton Studio</a>
+      <a href="https://ellsworth.ai" target="_blank" class="footer-link">Ellsworth.ai</a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
Adds Ellsworth.ai to the portfolio:

- **Experience section**: New entry at the top — Ellsworth.ai / Creator / 2026
- **Section intro**: Updated to "Creator, founder, and designer — spanning AI, SaaS, healthcare, and enterprise product design."
- **Header links**: Ellsworth.ai ghost button added alongside LinkedIn, GitHub, and hamilton.studio
- **Footer links**: Ellsworth.ai added for consistency

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQnt6TFKNo8YR9mMhUydUJ)_